### PR TITLE
Update error type for clamav 1.2.1

### DIFF
--- a/define.go
+++ b/define.go
@@ -125,7 +125,7 @@ const CL_INIT_DEFAULT C.uint = C.CL_INIT_DEFAULT
 
 // Wraps the corresponding error message
 func Strerr(code ErrorCode) error {
-	err := errors.New(C.GoString(C.cl_strerror(C.int(code))))
+	err := errors.New(C.GoString(C.cl_strerror(C.cl_error_t(code))))
 	return err
 }
 


### PR DESCRIPTION
This PR solves the following issues:

* https://github.com/ca110us/go-clamav/issues/9
* https://github.com/ca110us/go-clamav/issues/7

Using ClamAV 1.2.1, this issue pops up. So by changing from `C.int` to `C.cl_error_t`, this lib stays up-to-date with the latest ClamAV.