### PR TITLE
Add C wrapper to make cl_strerror reachable universally

### DIFF
--- a/define.go
+++ b/define.go
@@ -3,6 +3,15 @@ package goclamav
 /*
 #include <clamav.h>
 #include <stdlib.h>
+
+// TODO: Once the older signature for cl_strerr in clamav.h goes away:
+//      extern const char *cl_strerror(int clerror);
+//   one can remove this wrapper function.  Without it, Golang will not compile
+//   on systems with an older header file.  In June 2025 this was found to be
+//   the case on Amazon linux 2023.
+const char* local_cl_strerror(cl_error_t clerror) {
+  return cl_strerror(clerror);
+}
 */
 import "C"
 import "errors"
@@ -125,7 +134,7 @@ const CL_INIT_DEFAULT C.uint = C.CL_INIT_DEFAULT
 
 // Wraps the corresponding error message
 func Strerr(code ErrorCode) error {
-	err := errors.New(C.GoString(C.cl_strerror(C.cl_error_t(code))))
+	err := errors.New(C.GoString(C.local_cl_strerror(C.cl_error_t(code))))
 	return err
 }
 

--- a/load_test.go
+++ b/load_test.go
@@ -26,7 +26,7 @@ func TestInit(t *testing.T) {
 func ExampleRetver() {
 	fmt.Println(clamav.Retver())
 
-	// Output:
+	// Example output:
 	// 1.0.8
 }
 

--- a/load_test.go
+++ b/load_test.go
@@ -25,9 +25,6 @@ func TestInit(t *testing.T) {
 
 func ExampleRetver() {
 	fmt.Println(clamav.Retver())
-
-	// Example output:
-	// 1.0.8
 }
 
 func ExampleRetdbdir() {


### PR DESCRIPTION
This resolves #9 by creating a wrapper function which can be compiled with both older and newer clamav.h libraries.

clamav-devel-0.103.12-1.amzn2023.0.1.x86_64